### PR TITLE
[KAN-1/part]: Workaround of the typography implementation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@testing-library/jest-dom": "^5.17.0",
         "@testing-library/react": "^13.4.0",
         "@testing-library/user-event": "^13.5.0",
+        "classnames": "^2.5.1",
         "prop-types": "^15.8.1",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -6095,6 +6096,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clean-css": {
       "version": "5.3.3",
@@ -22543,6 +22549,11 @@
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/cjs-module-lexer/-/cjs-module-lexer-1.3.1.tgz",
       "integrity": "sha512-a3KdPAANPbNE4ZUv9h6LckSl9zLsYOP4MBmhIPkRaeyybt+r4UghLvq+xw/YwUcC1gqylCkL4rdVs3Lwupjm4Q=="
+    },
+    "classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "clean-css": {
       "version": "5.3.3",

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@testing-library/jest-dom": "^5.17.0",
     "@testing-library/react": "^13.4.0",
     "@testing-library/user-event": "^13.5.0",
+    "classnames": "^2.5.1",
     "prop-types": "^15.8.1",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/src/App.css
+++ b/src/App.css
@@ -7,3 +7,7 @@
     sans-serif;
   font-weight: 600; /* semi-bold */
 }
+
+html {
+  font-size: 16px; /* base font size */
+}

--- a/src/components/pages/Playground/Playground.jsx
+++ b/src/components/pages/Playground/Playground.jsx
@@ -1,9 +1,8 @@
-import React,{useState} from "react";
+import React, { useState } from "react";
 import styles from "./Playground.module.css";
 import Typography from "../../utility/Typography/Typography";
 import Button from "../../utility/Button/Button";
-import FormElement from '../../utility/FormElement/FormElement';
-
+import FormElement from "../../utility/FormElement/FormElement";
 
 const Playground = () => {
   const [value, setValue] = useState('');
@@ -16,14 +15,14 @@ const Playground = () => {
     } else {
       setError('');
     }
-  }
+  };
   return (
     <div className={styles.appHeader}>
-      <Typography elType="h1Large" className={styles.h1Large}>
+      <Typography elType="h1">
         Edit <code>src/App.js</code> and save to reload.
       </Typography>
 
-      <Typography elType="body1" className={styles.body1}>
+      <Typography elType="body1">
         <a
           className={styles.appLink}
           href="https://reactjs.org"
@@ -70,19 +69,17 @@ const Playground = () => {
           Tertiary Button
         </Button>
       </div>
-       {/* Form Element */}
-      <>
-      <Typography elType='h1Small' className={styles.h1Small}>
-          Form Elements
-      </Typography>
-      <FormElement
-        type="text"
-        placeholder="Message"
-        value={value}
-        onChange={handleChange}
-        error={error}
-      />
-      </>
+
+      <div>
+        <Typography elType="h2">Form Elements</Typography>
+        <FormElement
+          type="text"
+          placeholder="Message"
+          value={value}
+          onChange={handleChange}
+          error={error}
+        />
+      </div>
     </div>
   );
 };

--- a/src/components/pages/Playground/Playground.jsx
+++ b/src/components/pages/Playground/Playground.jsx
@@ -5,22 +5,26 @@ import Button from "../../utility/Button/Button";
 import FormElement from "../../utility/FormElement/FormElement";
 
 const Playground = () => {
-  const [value, setValue] = useState('');
-  const [error, setError] = useState('');
+  const [value, setValue] = useState("");
+  const [error, setError] = useState("");
 
   const handleChange = (event) => {
     setValue(event.target.value);
-    if (event.target.value === '') {
-      setError('This field is required');
+    if (event.target.value === "") {
+      setError("This field is required");
     } else {
-      setError('');
+      setError("");
     }
   };
   return (
     <div className={styles.appHeader}>
-      <Typography elType="h1">
-        Edit <code>src/App.js</code> and save to reload.
-      </Typography>
+      <h3>Typography</h3>
+      <Typography elType="h1Large">h1 Large Text</Typography>
+      <Typography elType="h1Small">H1 Small Text</Typography>
+      <Typography elType="body1">body1 Text</Typography>
+      <Typography elType="body2">body2 Text</Typography>
+      <Typography elType="h2">h2 Text</Typography>
+      <Typography elType="h3">h3 Text</Typography>
 
       <Typography elType="body1">
         <a

--- a/src/components/pages/Playground/Playground.module.css
+++ b/src/components/pages/Playground/Playground.module.css
@@ -11,16 +11,16 @@
 }
 
 .appHeader {
-    background-color: #282c34;
-    min-height: 100vh;
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    font-size: calc(10px + 2vmin);
-    color: white;
-  }
+  background-color: #282c34;
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  font-size: calc(10px + 2vmin);
+  color: white;
+}
 
-  .appLink {
-    color: #61dafb;
-  }
+.appLink {
+  color: #61dafb;
+}

--- a/src/components/utility/Typography/Typography.js
+++ b/src/components/utility/Typography/Typography.js
@@ -1,35 +1,47 @@
 import React from "react";
 import styles from "./Typography.module.css";
+import classNames from "classnames";
+import PropTypes from "prop-types";
 
 export const TypographyElements = {
   body1: "p",
   body2: "p",
   span: "span",
-  h1: "h1",
+  h1Large: "h1",
+  h1Small: "h1",
   h2: "h2",
   h3: "h3",
+  error: "p",
 };
 
-export default function Typography({
-  elType,
-  className = "",
-  id = "",
-  children,
-}) {
+const Typography = ({ elType, className = "", id = "", children }) => {
   if (!Object.keys(TypographyElements).includes(elType)) {
     throw TypeError("Unsupported element type for Typography component");
   }
-
-  var typographyStyle = `${styles[elType]}`;
-  if (className) {
-    typographyStyle += `${styles[className]}`;
-  }
-
   const Tag = TypographyElements[elType];
 
+  const combinedClassName = classNames(className, {
+    [styles.body1]: elType === "body1",
+    [styles.body2]: elType === "body2",
+    [styles.h1Large]: elType === "h1Large",
+    [styles.h1Small]: elType === "h1Small",
+    [styles.h2]: elType === "h2",
+    [styles.h3]: elType === "h3",
+    [styles.error]: elType === "error",
+  });
+
   return (
-    <Tag className={typographyStyle} id={id}>
+    <Tag className={combinedClassName} id={id}>
       {children}
     </Tag>
   );
-}
+};
+
+Typography.propTypes = {
+  elType: PropTypes.oneOf(Object.keys(TypographyElements)).isRequired,
+  className: PropTypes.string,
+  id: PropTypes.string,
+  children: PropTypes.node.isRequired,
+};
+
+export default Typography;

--- a/src/components/utility/Typography/Typography.js
+++ b/src/components/utility/Typography/Typography.js
@@ -1,29 +1,35 @@
-import React from 'react';
+import React from "react";
+import styles from "./Typography.module.css";
 
 export const TypographyElements = {
-  "body1": "p",
-  "body2": "p",
-  "span": "span",
-  "h1Small": "h1",
-  "h1Large": "h1",
-  "h2": "h2",
-  "h3": "h3",
-}
+  body1: "p",
+  body2: "p",
+  span: "span",
+  h1: "h1",
+  h2: "h2",
+  h3: "h3",
+};
 
-export default function Typography(
-  { elType, className = "", id = "", children }
-) {
+export default function Typography({
+  elType,
+  className = "",
+  id = "",
+  children,
+}) {
   if (!Object.keys(TypographyElements).includes(elType)) {
-    throw TypeError("Unsupported element type for Typography component")
-  };
+    throw TypeError("Unsupported element type for Typography component");
+  }
 
-  className = `${elType} ${className}`;
+  var typographyStyle = `${styles[elType]}`;
+  if (className) {
+    typographyStyle += `${styles[className]}`;
+  }
 
   const Tag = TypographyElements[elType];
 
   return (
-    <Tag className={className} id={id}>
+    <Tag className={typographyStyle} id={id}>
       {children}
     </Tag>
-  )
+  );
 }

--- a/src/components/utility/Typography/Typography.module.css
+++ b/src/components/utility/Typography/Typography.module.css
@@ -4,17 +4,18 @@ h3 {
   font-weight: 700; /* bold */
 }
 
-h1 {
+.h1Large,
+.h1Small {
   font-size: 2.5rem;
   line-height: 2.5rem;
 }
 
-h2 {
+.h2 {
   font-size: 2rem;
   line-height: 2rem;
 }
 
-h3,
+.h3,
 .body1 {
   font-size: 0.9rem;
   line-height: 1.75rem;
@@ -26,24 +27,30 @@ h3,
 }
 
 @media (min-width: 768px) {
-  h1 {
+  .h1Large,
+  .h1Small {
     font-size: 4rem;
     line-height: 3.5rem;
   }
 }
 
 @media (min-width: 960px) {
-  h1 {
+  .h1Large {
     font-size: 6.25rem;
     line-height: 6.25rem;
   }
 
-  h2 {
+  .h1Small {
+    font-size: 4rem;
+    line-height: 6.25rem;
+  }
+
+  .h2 {
     font-size: 3rem;
     line-height: 3rem;
   }
 
-  h3,
+  .h3,
   .body1 {
     font-size: 1.12rem;
   }

--- a/src/components/utility/Typography/Typography.module.css
+++ b/src/components/utility/Typography/Typography.module.css
@@ -1,58 +1,48 @@
-/* defined in App.css:
-@import url('https://fonts.googleapis.com/css2?family=Livvic:ital,wght@0,600;0,700;1,600;1,700&display=swap');
-
-body {
-  font-family: "Livvic", -apple-system, BlinkMacSystemFont, 'Segoe UI',
-    'Roboto', 'Oxygen', 'Ubuntu', 'Cantarell', 'Fira Sans', 'Droid Sans',
-    'Helvetica Neue', sans-serif;
-  font-weight: 600;
-}
-*/
-
-h1, h2, h3 {
+h1,
+h2,
+h3 {
   font-weight: 700; /* bold */
 }
 
-h1, h1.h1Large {
-  font-size: 64px;
-  line-height: 56px;
+h1 {
+  font-size: 2.5rem;
+  line-height: 2.5rem;
 }
 
 h2 {
-  font-size: 32px;
-  line-height: 32px;
+  font-size: 2rem;
+  line-height: 2rem;
 }
 
-h3 {
-  font-size: 18px;
-  line-height: 28px;
-}
-
-.body1 {
-  font-size: 18px;
-  line-height: 28px;
+h3 .body1 {
+  font-size: 0.9rem;
+  line-height: 1.75rem;
 }
 
 .body2 {
-  font-size: 15px;
-  line-height: 25px;
+  font-size: 0.9rem;
+  line-height: 1.5rem;
 }
 
-@media (width >= 960px) {
-  h1.h1Large {
-    font-size: 100px;
-    line-height: 100px;
+@media (min-width: 768px) {
+  h1 {
+    font-size: 4rem;
+    line-height: 3.5rem;
+  }
+}
+
+@media (min-width: 960px) {
+  h1 {
+    font-size: 6.25rem;
+    line-height: 6.25rem;
   }
 
   h2 {
-    font-size: 48px;
-    line-height: 48px;
+    font-size: 3rem;
+    line-height: 3rem;
   }
-}
 
-@media (width < 768px) {
-  h1, h1.h1Large {
-    font-size: 40px;
-    line-height: 40px;
+  h3 .body1 {
+    font-size: 1.12rem;
   }
 }

--- a/src/components/utility/Typography/Typography.module.css
+++ b/src/components/utility/Typography/Typography.module.css
@@ -14,7 +14,8 @@ h2 {
   line-height: 2rem;
 }
 
-h3 .body1 {
+h3,
+.body1 {
   font-size: 0.9rem;
   line-height: 1.75rem;
 }
@@ -42,7 +43,8 @@ h3 .body1 {
     line-height: 3rem;
   }
 
-  h3 .body1 {
+  h3,
+  .body1 {
     font-size: 1.12rem;
   }
 }


### PR DESCRIPTION
Reasons for using `rem`  over `px`:
**Scalability and Accessibility:** rem units scale relative to the root font size, which means adjusting the base font size of the document will proportionally scale all elements using rem units. 

**Consistency**: Using rem units ensures consistent scaling of font sizes across the entire project. Changes to the root font size will uniformly affect all elements, reducing the risk of inconsistent font sizes that can occur with px units.

**Maintainability**: rem units simplify maintenance and scalability of styles. Developers can adjust the base font size to change the overall scale of the text, instead of updating individual px values throughout the CSS, making it easier to manage and update styles.

**Better Performance**: Using rem units can result in fewer calculations by the browser compared to percentage-based or em units, potentially improving rendering performance.

**The Base font size has been explicitly set as 16px in the App.css file**

**classname**: The classNames function from the classnames library combines the parent component's class with the variant-specific class and a base class (if provided).


