### PR TITLE
[NOTASK] fix CD build: add devDependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,9 @@
         "react-router-dom": "^6.23.1",
         "react-scripts": "5.0.1",
         "web-vitals": "^2.1.4"
+      },
+      "devDependencies": {
+        "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
       }
     },
     "node_modules/@adobe/css-tools": {
@@ -663,9 +666,17 @@
       }
     },
     "node_modules/@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "deprecated": "This proposal has been merged to the ECMAScript standard and thus this plugin is no longer maintained. Please use @babel/plugin-transform-private-property-in-object instead.",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      },
       "engines": {
         "node": ">=6.9.0"
       },
@@ -1901,6 +1912,17 @@
         "core-js-compat": "^3.31.0",
         "semver": "^6.3.1"
       },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/preset-env/node_modules/@babel/plugin-proposal-private-property-in-object": {
+      "version": "7.21.0-placeholder-for-preset-env.2",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
       "engines": {
         "node": ">=6.9.0"
       },
@@ -18890,10 +18912,16 @@
       }
     },
     "@babel/plugin-proposal-private-property-in-object": {
-      "version": "7.21.0-placeholder-for-preset-env.2",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
-      "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
-      "requires": {}
+      "version": "7.21.11",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.11.tgz",
+      "integrity": "sha512-0QZ8qP/3RLDVBwBFoWAwCtgcDZJVwA5LUJRZU8x2YFfKNuFq161wK3cuGrALu5yiPu+vzwTAg/sMWVNeWeNyaw==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.18.6",
+        "@babel/helper-create-class-features-plugin": "^7.21.0",
+        "@babel/helper-plugin-utils": "^7.20.2",
+        "@babel/plugin-syntax-private-property-in-object": "^7.14.5"
+      }
     },
     "@babel/plugin-syntax-async-generators": {
       "version": "7.8.4",
@@ -19688,6 +19716,12 @@
         "semver": "^6.3.1"
       },
       "dependencies": {
+        "@babel/plugin-proposal-private-property-in-object": {
+          "version": "7.21.0-placeholder-for-preset-env.2",
+          "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-private-property-in-object/-/plugin-proposal-private-property-in-object-7.21.0-placeholder-for-preset-env.2.tgz",
+          "integrity": "sha512-SOSkfJDddaM7mak6cPEpswyTRnuRltl429hMraQEglW+OkovnCzsiszTmsrlY//qLFjCpQDFRvjdm2wA5pPm9w==",
+          "requires": {}
+        },
         "semver": {
           "version": "6.3.1",
           "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",

--- a/package.json
+++ b/package.json
@@ -41,5 +41,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "@babel/plugin-proposal-private-property-in-object": "^7.21.11"
   }
 }

--- a/src/components/About/Clients.jsx
+++ b/src/components/About/Clients.jsx
@@ -10,7 +10,7 @@ import containerImage from "../../assets/bg-pattern-about-4.svg";
 const Clients = () => {
   return (
     <section className={styles.container}>
-      <img src={containerImage} alt="geometric background flourish" className={styles.containerImage} />
+      <img src={containerImage} alt="" className={styles.containerImage} />
       <Typography elType="h2" className={styles.title}>
         Some of our clients
       </Typography>

--- a/src/components/About/Clients.jsx
+++ b/src/components/About/Clients.jsx
@@ -10,7 +10,7 @@ import containerImage from "../../assets/bg-pattern-about-4.svg";
 const Clients = () => {
   return (
     <section className={styles.container}>
-      <img src={containerImage} className={styles.containerImage} />
+      <img src={containerImage} alt="geometric background flourish" className={styles.containerImage} />
       <Typography elType="h2" className={styles.title}>
         Some of our clients
       </Typography>


### PR DESCRIPTION
- a babel dependency in the unmaintained create-react-app library was throwing build errors and the build log at https://github.com/poulami-saha/Global-Code-Queens-MyTeam-Website/actions/runs/9784154678/job/27014421185 describes adding the problem library as a devDependency to silence errors:
    ```
      One of your dependencies, babel-preset-react-app, is importing the
      "@babel/plugin-proposal-private-property-in-object" package without
      declaring it in its dependencies. This is currently working because
      "@babel/plugin-proposal-private-property-in-object" is already in your
      node_modules folder for unrelated reasons, but it may break at any time.

      babel-preset-react-app is part of the create-react-app project, which
      is not maintianed anymore. It is thus unlikely that this bug will
      ever be fixed. Add "@babel/plugin-proposal-private-property-in-object" to
      your devDependencies to work around this error. This will make this message
      go away.
    ```
- also added alt text on an img file to fix a warning in local logs (and increase accessibility)
    ```
      WARNING in [eslint]
      src/components/About/Clients.jsx
        Line 13:7:  img elements must have an alt prop, either with meaningful text, 
        or an empty string for decorative images  jsx-a11y/alt-text
    ```