### PR TITLE
Refactor button styles

### DIFF
--- a/src/components/About/ProfileCard.module.css
+++ b/src/components/About/ProfileCard.module.css
@@ -66,12 +66,15 @@
 .mainButton {
   position: absolute;
   bottom: 0px;
-  padding: 0;
   width: 56px;
   height: 56px;
-  border-radius: 50%;
-  border-style: none;
   -webkit-tap-highlight-color: transparent;
+}
+
+.card .mainButton {
+  padding: 18px;
+  border-style: none;
+  border-radius: 50%;
 }
 
 .hideButton,

--- a/src/components/Contact/ContactForm.jsx
+++ b/src/components/Contact/ContactForm.jsx
@@ -128,7 +128,7 @@ const ContactForm = () => {
           />
         )
       )}
-      <Button type="secondary" disabled={!isFormValid()}>
+      <Button elType="secondary" disabled={!isFormValid()}>
         Submit
       </Button>
     </form>

--- a/src/components/pages/Playground/Playground.jsx
+++ b/src/components/pages/Playground/Playground.jsx
@@ -75,8 +75,27 @@ const Playground = () => {
         </Button>
         <Button type="secondary" elType="white" disabled className={styles.buttonMargin}>
         Disabled Secondary Color Button
-      </Button>
+        </Button>
       </div>
+
+      {/* showMore buttons */}
+      <Button
+        elType="showMore"
+        onClick={() => alert("Show More Button Clicked")}
+        className={styles.buttonMargin}
+      >
+        Show More Button
+      </Button>
+
+      {/* hideMore buttons */}
+      <Button
+        elType="hideMore"
+        onClick={() => alert("Hide More Button Clicked")}
+        className={styles.buttonMargin}
+      >
+        Hide More Button
+      </Button>
+
       <div>
         <Typography elType="body1">Form Elements</Typography>
         <FormElement

--- a/src/components/pages/Playground/Playground.jsx
+++ b/src/components/pages/Playground/Playground.jsx
@@ -40,40 +40,39 @@ const Playground = () => {
       <Typography elType="h3">Primary button light</Typography>
       <div className={`${styles.buttonContainer} ${styles.buttonContainerColor}`}>
         <Button
-          elType="white"
+          elType="primaryWhite"
           onClick={() => alert("Primary light Button Clicked")}
           className={styles.buttonMargin}
         >
           White Color Button
         </Button>
-        <Button elType="white" disabled className={styles.buttonMargin}>
+        <Button elType="primaryWhite" disabled className={styles.buttonMargin}>
           Disabled White Color Button
         </Button>
       </div>
       {/* Primary buttons */}
       <Typography elType="h3">Primary button dark</Typography>
       <Button
-        elType="dark"
+        elType="primaryDark"
         onClick={() => alert("Primary dark Button Clicked")}
         className={styles.buttonMargin}
       >
         Dark Color Button
       </Button>
-      <Button elType="white" disabled className={styles.buttonMargin}>
-        Disabled White Color Button
+      <Button elType="primaryDark" disabled className={styles.buttonMargin}>
+        Disabled Dark Color Button
       </Button>
       {/* secondary buttons */}
       <Typography elType="h3">Secondary button</Typography>
       <div className={`${styles.buttonContainer} ${styles.buttonContainerColor}`}>
         <Button
-          type="secondary"
-          elType="white"
+          elType="secondary"
           onClick={() => alert("Secondary Button Clicked")}
           className={styles.buttonMargin}
         >
           Secondary Button
         </Button>
-        <Button type="secondary" elType="white" disabled className={styles.buttonMargin}>
+        <Button elType="secondary" disabled className={styles.buttonMargin}>
         Disabled Secondary Color Button
         </Button>
       </div>

--- a/src/components/utility/Button/Button.jsx
+++ b/src/components/utility/Button/Button.jsx
@@ -25,8 +25,7 @@ const Button = ({ elType, disabled = false, onClick, children, className }) => {
 };
 
 Button.propTypes = {
-  elType: PropTypes.oneOf(["white", "dark", "showMore", "hideMore"]),
-  type: PropTypes.oneOf(["primary", "secondary"]),
+  elType: PropTypes.oneOf(["primaryWhite", "primaryDark", "secondary", "showMore", "hideMore"]),
   disabled: PropTypes.bool,
   onClick: PropTypes.func,
   children: PropTypes.node.isRequired,

--- a/src/components/utility/Button/Button.jsx
+++ b/src/components/utility/Button/Button.jsx
@@ -3,64 +3,22 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import styles from "./Button.module.css";
 
-const buttonColorStyle = {
-  primary: {
-    white: {
-      color: "#fff",
-      borderColor: "#fff",
-      hoverBackgroundColor: "white",
-      hoverColor: "#002529",
-    },
-    dark: {
-      color: "#012F34",
-      borderColor: "#012F34",
-      hoverBackgroundColor: "#012F34",
-      hoverColor: "#fff",
-    },
-    showMore: {
-      color: "#012F34",
-      backgroundColor: "#f67e7e",
-      borderColor: "#012F34",
-      hoverBackgroundColor: "#79c8c7",
-      hoverColor: "#012F34",
-    },
-    hideMore: {
-      color: "#012F34",
-      backgroundColor: "#79c8c7",
-      borderColor: "#012F34",
-      hoverBackgroundColor: "#f67e7e",
-      hoverColor: "#012F34",
-    },
-  },
-  secondary: {
-    color: "#002529",
-    hoverBackgroundColor: "#79C8C7",
-    hoverColor: "#002529",
-  },
-};
-
 const Button = ({ type = "primary", elType, disabled = false, onClick, children, className }) => {
   const isSecondary = type === "secondary";
   const buttonClass = classNames(styles.button, className, {
     [styles.disabled]: disabled,
     [styles.buttonSecondary]: isSecondary,
-  });
-
-  const buttonStyle = isSecondary ? buttonColorStyle.secondary : buttonColorStyle.primary[elType];
-  const colorConfig = {
-    "--button-color": buttonStyle.color,
-    "--button-background-color": buttonStyle.backgroundColor,
-    "--button-border-color": buttonStyle.borderColor,
-    "--button-hover-background-color": buttonStyle.hoverBackgroundColor,
-    "--button-hover-color": buttonStyle.hoverColor,
-  };
+    [styles.buttonPrimaryDark]: type === "primary" && elType === "dark",
+    [styles.buttonPrimaryWhite]: type ==="primary" && elType === "white",
+    [styles.buttonShowMore]: elType === "showMore",
+    [styles.buttonHideMore]: elType === "hideMore",
+  })
 
   return (
     <button
       className={buttonClass}
       onClick={disabled ? null : onClick}
       disabled={disabled}
-      style={colorConfig}
     >
       {children}
     </button>
@@ -68,7 +26,7 @@ const Button = ({ type = "primary", elType, disabled = false, onClick, children,
 };
 
 Button.propTypes = {
-  elType: PropTypes.oneOf(["white", "dark"]),
+  elType: PropTypes.oneOf(["white", "dark", "showMore", "hideMore"]),
   type: PropTypes.oneOf(["primary", "secondary"]),
   disabled: PropTypes.bool,
   onClick: PropTypes.func,

--- a/src/components/utility/Button/Button.jsx
+++ b/src/components/utility/Button/Button.jsx
@@ -3,15 +3,14 @@ import PropTypes from "prop-types";
 import classNames from "classnames";
 import styles from "./Button.module.css";
 
-const Button = ({ type = "primary", elType, disabled = false, onClick, children, className }) => {
-  const isSecondary = type === "secondary";
+const Button = ({ elType, disabled = false, onClick, children, className }) => {
   const buttonClass = classNames(styles.button, className, {
     [styles.disabled]: disabled,
-    [styles.buttonSecondary]: isSecondary,
-    [styles.buttonPrimaryDark]: type === "primary" && elType === "dark",
-    [styles.buttonPrimaryWhite]: type ==="primary" && elType === "white",
-    [styles.buttonShowMore]: elType === "showMore",
-    [styles.buttonHideMore]: elType === "hideMore",
+    [styles.buttonPrimaryDark]:   elType === "primaryDark",
+    [styles.buttonPrimaryWhite]:  elType === "primaryWhite",
+    [styles.buttonSecondary]:     elType === "secondary",
+    [styles.buttonShowMore]:      elType === "showMore",
+    [styles.buttonHideMore]:      elType === "hideMore",
   })
 
   return (

--- a/src/components/utility/Button/Button.jsx
+++ b/src/components/utility/Button/Button.jsx
@@ -25,8 +25,11 @@ const buttonColorStyle = {
       hoverColor: "#012F34",
     },
     hideMore: {
-      backgroundColor: "",
-      hoverBackgroundColor: "",
+      color: "#012F34",
+      backgroundColor: "#79c8c7",
+      borderColor: "#012F34",
+      hoverBackgroundColor: "#f67e7e",
+      hoverColor: "#012F34",
     },
   },
   secondary: {

--- a/src/components/utility/Button/Button.module.css
+++ b/src/components/utility/Button/Button.module.css
@@ -1,11 +1,17 @@
 .button {
+  /* default button colors */
+  --button-color: gold;
+  --button-background-color: transparent;
+  --button-border-color: gold;
+  --button-hover-background-color: red;
+  --button-hover-color: black;
+  /* END default button colors */
   padding: 10px 20px;
   border: 2px solid var(--button-border-color);
   border-radius: 24px;
   cursor: pointer;
   font-size: 1rem;
   transition: background-color 0.3s, color 0.3s, border-color 0.3s;
-  background-color: transparent;
   background-color: var(--button-background-color);
   color: var(--button-color);
 }
@@ -15,42 +21,94 @@
   color: var(--button-hover-color);
 }
 
-.disabled {
+.disabled,
+.disabled[disabled] {
   /* color: var(--primary-disabled-color);
   border-color: var(--primary-disabled-border); */
   opacity: 0.25;
   cursor: not-allowed;
 }
 
-/* Secondary Button */
-.buttonSecondary {
-  background-color: var(--primary-white);
-  color: var(--dark-green);
+/* PrimaryDark Button */
+.buttonPrimaryDark {
+  --button-color: var(--dark-theme-background);
+  --button-background-color: transparent;
+  --button-border-color: var(--dark-theme-background);
+  --button-hover-background-color: var(--dark-theme-background);
+  --button-hover-color: var(--primary-white);
 }
 
-.buttonSecondaryHover:hover {
+/* PrimaryWhite Button */
+.buttonPrimaryWhite {
+  --button-color: var(--primary-white);
+  --button-background-color: transparent;
+  --button-border-color: var(--primary-white);
+  --button-hover-background-color: var(--primary-white);
+  --button-hover-color: var(--dark-green);
+}
+
+/* ShowMore Button */
+.buttonShowMore {
+  --button-color: var(--dark-theme-background);
+  --button-background-color: var(--coral-color);
+  --button-border-color: var(--dark-theme-background)
+  border-width: 0;
+}
+
+.buttonShowMore:hover {
+  --button-hover-background-color: var(--rapture-blue);
+  --button-hover-color: var(--dark-theme-background);
+}
+
+/* HideMore Button */
+.buttonHideMore {
+  --button-color: var(--dark-theme-background);
+  --button-background-color: var(--rapture-blue);
+  --button-border-color: var(--dark-theme-background)
+  border-width: 0;
+}
+
+.buttonHideMore:hover {
+  --button-hover-background-color: var(--coral-color);
+  --button-hover-color: var(--dark-theme-background);
+}
+
+/* Secondary Button */
+.buttonSecondary {
+  --button-color: var(--dark-green);
+  --button-background-color: var(--primary-white);
+  --button-border-color: var(--rapture-blue);
+  --button-hover-background-color: var(--rapture-blue);
+  border-width: 0;
+}
+
+/* 
+.buttonSecondary:hover {
   background-color: var(--rapture-blue);
   border: var(--rapture-blue);
 }
 
-/* .buttonSecondaryDisabled:disabled {
+.buttonSecondary:disabled {
   background-color: var(--primary-white);
   opacity: 0.25;
-} */
+}
+*/
 
 /* Tertiary Button */
+/*
 .buttonTertiary {
   background-color: var(--primary-white);
   color: var(--dark-theme-background);
   border: 2px solid var(--dark-theme-background);
 }
 
-.buttonTertiaryHover:hover {
+.buttonTertiary:hover {
   background-color: var(--dark-theme-background);
   color: var(--primary-white);
 }
 
-.buttonTertiaryDisabled:disabled {
+.buttonTertiary:disabled {
   color: var(--tertiary-disabled-color);
   border: 2px solid var(--tertiary-disabled-border-color);
 }
+*/

--- a/src/components/utility/Button/Button.module.css
+++ b/src/components/utility/Button/Button.module.css
@@ -6,6 +6,7 @@
   font-size: 1rem;
   transition: background-color 0.3s, color 0.3s, border-color 0.3s;
   background-color: transparent;
+  background-color: var(--button-background-color);
   color: var(--button-color);
 }
 


### PR DESCRIPTION
- Add show/hide buttons to Playground
- Tweak centering of icons on ProfileCards (on About page, in Directors section)
- Use only CSS modules to style buttons, without resorting to the `style` property in HTML
- Use only one property to set button styles (got rid of `type` and uses only `elType`)
- Commented out unused rules for secondary and tertiary styles