### PR TITLE
[NOTASK]: Update styling of Home > Success Stories

### DIFF
--- a/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
+++ b/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
@@ -79,13 +79,13 @@
 @media (min-width: 960px) {
   .wrapper {
     padding-block: 140px;
-    max-width: 1148px;
-    box-sizing: content-box;
   }
 
   .contents {
     flex-direction: row;
     gap: 30px;
+    max-width: 1148px;
+    box-sizing: border-box;
   }
 
   .quote {

--- a/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
+++ b/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
@@ -80,7 +80,7 @@
   .wrapper {
     padding-block: 140px;
     max-width: 1148px;
-    box-sizing: border-box;
+    box-sizing: content-box;
   }
 
   .contents {

--- a/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
+++ b/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
@@ -81,13 +81,22 @@
   }
 
   .contents {
-    flex-direction: row;
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    align-items: end;
     gap: 30px;
     max-width: 1148px;
+    margin-inline: auto;
   }
 
   .quote {
-    width: calc(100% / 3);
+    display: grid;
+    grid-template-rows: 1fr;
+    height: 100%;
+  }
+
+  .quote > :first-child {
+    align-self: start;
   }
 
   .heading {

--- a/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
+++ b/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
@@ -29,14 +29,14 @@
 /* content */
 .quote {
   width: 100%;
-  padding-block: 10px;
-  background: transparent url("../../../assets/icon-quotes.svg") no-repeat center top / 56px 56px;
+  padding-top: 36px;
+  background: transparent url("../../../assets/icon-quotes.svg") no-repeat center top / 67px 56px;
 }
 
 /* image */
 .image {
-  width: 60px;
-  height: 60px;
+  width: 66px;
+  height: 66px;
   margin: 0 auto;
   border-radius: 50%;
   border: 2px solid var(--rapture-blue);
@@ -62,10 +62,11 @@
 
 .name {
   color: var(--rapture-blue);
+  margin: 16px 0 2px 0;
 }
 
 .caption {
-  padding-bottom: 10px;
+  padding-bottom: 14px;
 }
 
 /* media queries */
@@ -78,7 +79,6 @@
 @media (min-width: 960px) {
   .wrapper {
     padding-block: 140px;
-    max-width: 1148px;
   }
 
   .contents {
@@ -88,5 +88,18 @@
 
   .quote {
     width: calc(100% / 3);
+  }
+
+  .heading {
+    padding: 0 89px;
+    margin-bottom: 56px;
+  }
+
+  .name {
+    margin-top: 24px;
+  }
+
+  .caption {
+    padding-bottom: 30px;
   }
 }

--- a/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
+++ b/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
@@ -79,6 +79,8 @@
 @media (min-width: 960px) {
   .wrapper {
     padding-block: 140px;
+    max-width: 1148px;
+    box-sizing: border-box;
   }
 
   .contents {

--- a/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
+++ b/src/components/HomeContainer/SuccessStories/SuccessStories.module.css
@@ -12,7 +12,6 @@
 
 /*wrapper*/
 .wrapper {
-  box-sizing: border-box;
   padding-block: 140px;
   margin: 0 auto;
   width: 100%;
@@ -85,7 +84,6 @@
     flex-direction: row;
     gap: 30px;
     max-width: 1148px;
-    box-sizing: border-box;
   }
 
   .quote {

--- a/src/components/HomeContainer/SuccessStories/SuccessStory.jsx
+++ b/src/components/HomeContainer/SuccessStories/SuccessStory.jsx
@@ -6,7 +6,7 @@ const SuccessStory = ({ quote, name, title, avatar, altText }) => {
   return (
     <article className={styles.quote}>
       <Typography elType="body2">“{quote}”</Typography>
-      <Typography elType="h3Large" className={styles.name}>
+      <Typography elType="h3" className={styles.name}>
         {name}
       </Typography>
       <Typography elType="body3" className={styles.caption}>


### PR DESCRIPTION
*I made sure to not change any of the updates made in [[NOTASK]: unify gutter spacing, header spacing](https://github.com/poulami-saha/Global-Code-Queens-MyTeam-Website/pull/39/files#top) 
~~with the exception of one (see comments) which can be easily added back if necessary.~~

Updated styling of Success Stories
- spacing between elements especially at desktop width
- size of image
- font size of author name

BEFORE:
![BEFORE](https://github.com/user-attachments/assets/00ce4d36-3450-4aaf-a74f-59ea454dab5f)
AFTER:
![AFTER](https://github.com/user-attachments/assets/9738f866-473d-4bb8-9f90-561bbc9d59cf)
