### PR TITLE
[NOTASK]: add max-width to prevent 4-col layout of director profiles

### DIFF
--- a/src/components/AboutContainer/Directors/Directors.module.css
+++ b/src/components/AboutContainer/Directors/Directors.module.css
@@ -58,5 +58,6 @@
   .profiles {
     margin-top: 4rem;
     column-gap: 1.875rem;
+    max-width: 1200px;
   }
 }


### PR DESCRIPTION
As an alternative to #41, this PR prevents 4-column or more layout of director profiles by setting a max-width on the containing element with class `.profiles` 