### PR TITLE
[NOTASK]: refactor Clients layout and update snapshot

### DIFF
--- a/src/components/AboutContainer/Clients/Clients.jsx
+++ b/src/components/AboutContainer/Clients/Clients.jsx
@@ -10,27 +10,29 @@ import gadgetsNow from "../../../assets/logo-gadgets-now.png";
 const Clients = () => {
   return (
     <section className={styles.container}>
-      <Typography elType="h2" className={styles.title}>
-        Some of our clients
-      </Typography>
-      <div className={styles.news}>
-        <img src={verge} alt="The Verge" className={styles.logoVerge} />
-        <img
-          src={jakarta}
-          alt="TheJakarta Post"
-          className={styles.logoJakarta}
-        />
-        <img
-          src={guardian}
-          alt="The Guardian"
-          className={styles.logoGuardian}
-        />
-        <img src={techRadar} alt="techRadar" className={styles.logoTechRadar} />
-        <img
-          src={gadgetsNow}
-          alt="Gadgets Now"
-          className={styles.logoGadgets}
-        />
+      <div className={styles.body}>
+        <Typography elType="h2" className={styles.title}>
+          Some of our clients
+        </Typography>
+        <div className={styles.news}>
+          <img src={verge} alt="The Verge" className={styles.logoVerge} />
+          <img
+            src={jakarta}
+            alt="The Jakarta Post"
+            className={styles.logoJakarta}
+          />
+          <img
+            src={guardian}
+            alt="The Guardian"
+            className={styles.logoGuardian}
+          />
+          <img src={techRadar} alt="Tech Radar" className={styles.logoTechRadar} />
+          <img
+            src={gadgetsNow}
+            alt="Gadgets Now"
+            className={styles.logoGadgets}
+          />
+        </div>
       </div>
     </section>
   );

--- a/src/components/AboutContainer/Clients/Clients.module.css
+++ b/src/components/AboutContainer/Clients/Clients.module.css
@@ -1,30 +1,26 @@
 .container {
   background: var(--dark-theme-background);
-  display: flex;
+  height: 632px;
+  background-image: url("../../../assets/bg-pattern-about-4.svg");
+  background-position: top -100px left -100px;
+  background-repeat: no-repeat;  display: flex;
   flex-direction: column;
   justify-content: center;
   align-items: center;
-  height: 632px;
-  position: relative;
-  overflow-y: hidden;
-}
-.container::after {
-  content: "";
-  position: absolute;
 }
 
-.container::after {
-  width: 200px;
-  height: 200px;
-  top: 0px;
-  left: 0px;
-  transform: translate(-50%, -50%);
-  background-image: url("../../../assets/bg-pattern-about-4.svg");
+.body {
+  display: block;
+  width: 100%;
+  container-type: inline-size;
+  container-name: body-clients;
 }
+
 .title {
   color: #fff;
   margin-bottom: 64px;
   margin-top: 24px;
+  text-align: center;
 }
 
 .news {
@@ -33,99 +29,98 @@
   align-items: center;
   gap: 3.5rem;
 }
-.logoVerge {
+
+.logoVerge,
+.logoGuardian,
+.logoTechRadar {
   height: 1.5rem;
-  width: 8rem;
-}
-.logoJakarta {
-  height: 1.5rem;
-  width: 10rem;
-}
-.logoGuardian {
-  height: 1.5rem;
-  width: 10rem;
+  width: auto;
 }
 
-.logoTechRadar {
-  height: 2rem;
-  width: 10rem;
+.logoJakarta {
+  height: 1.25rem;
+  width: auto;
 }
+
 .logoGadgets {
-  height: 3rem;
-  width: 8rem;
+  height: 2.5rem;
+  width: auto;
 }
 
 @media (min-width: 768px) {
   .container {
-    padding-inline: 40px;
     height: 308px;
-    overflow-x: hidden;
+    background-position: top -100px left;
   }
+
+  .body {
+    width: calc(100% + 58px + 58px); /* match 39px header/footer gutters */
+  }
+
   .title {
     margin-bottom: 48px;
+    margin-top: 0;
   }
+
   .news {
     flex-direction: row;
     gap: 2.5rem;
+    justify-content: space-between;
+    max-width: 690px;
+    margin-inline: auto;
   }
 
-  .logoVerge {
-    height: 1rem;
-    width: 6rem;
-  }
-  .logoJakarta {
-    height: 1rem;
-    width: 8rem;
-  }
-  .logoGuardian {
-    height: 1rem;
-    width: 8rem;
-  }
-
+  .logoVerge,
+  .logoGuardian,
   .logoTechRadar {
-    height: 1.5rem;
-    width: 8rem;
+    height: 1.07rem;
   }
+
+  .logoJakarta {
+    height: 0.88rem;
+  }
+
   .logoGadgets {
-    height: 1.5rem;
-    width: 6rem;
-  }
-  .container::after {
-    height: 200px;
-    width: 200px;
-    transform: translate(0, -45%);
+    height: 1.75rem;
   }
 }
 
 @media (min-width: 960px) {
   .container {
     height: 437px;
+    background-position: top left;
   }
-  .container::after {
-    transform: none;
+
+  .body {
+    width: 100%;
   }
+
   .news {
-    flex-direction: row;
-    justify-content: space-between;
+    flex-wrap: wrap;
+    justify-content: space-around;
+    max-width: unset;
   }
-  .logoVerge {
-    height: 1.5rem;
-    width: 8rem;
-  }
-  .logoJakarta {
-    height: 1.5rem;
-    width: 10rem;
-  }
-  .logoGuardian {
-    height: 1.5rem;
-    width: 10rem;
-  }
+
+  .logoVerge,
+  .logoGuardian,
   .logoTechRadar {
-    height: 2rem;
-    width: 10rem;
+    height: 1.75rem;
   }
+
+  .logoJakarta {
+    height: 1.45rem;
+  }
+
   .logoGadgets {
-    height: 3rem;
-    width: 8rem;
+    height: 2.82rem;
+  }
+}
+
+/* container queries check the size of an element */
+@container body-clients (min-width: 955px) {
+  /* remove leftmost and rightmost spacing
+    when 5 logos can render on one line */
+  .news {
+    justify-content: space-between;
   }
 }

--- a/src/components/AboutContainer/Clients/__snapshots__/Clients.spec.js.snap
+++ b/src/components/AboutContainer/Clients/__snapshots__/Clients.spec.js.snap
@@ -5,40 +5,44 @@ exports[`renders NotFound correctly and matches snapshot 1`] = `
   <section
     class="container"
   >
-    <h2
-      class="title h2"
-      id=""
-    >
-      Some of our clients
-    </h2>
     <div
-      class="news"
+      class="body"
     >
-      <img
-        alt="The Verge"
-        class="logoVerge"
-        src="logo-the-verge.png"
-      />
-      <img
-        alt="TheJakarta Post"
-        class="logoJakarta"
-        src="logo-jakarta-post.png"
-      />
-      <img
-        alt="The Guardian"
-        class="logoGuardian"
-        src="logo-the-guardian.png"
-      />
-      <img
-        alt="techRadar"
-        class="logoTechRadar"
-        src="logo-tech-radar.png"
-      />
-      <img
-        alt="Gadgets Now"
-        class="logoGadgets"
-        src="logo-gadgets-now.png"
-      />
+      <h2
+        class="title h2"
+        id=""
+      >
+        Some of our clients
+      </h2>
+      <div
+        class="news"
+      >
+        <img
+          alt="The Verge"
+          class="logoVerge"
+          src="logo-the-verge.png"
+        />
+        <img
+          alt="The Jakarta Post"
+          class="logoJakarta"
+          src="logo-jakarta-post.png"
+        />
+        <img
+          alt="The Guardian"
+          class="logoGuardian"
+          src="logo-the-guardian.png"
+        />
+        <img
+          alt="Tech Radar"
+          class="logoTechRadar"
+          src="logo-tech-radar.png"
+        />
+        <img
+          alt="Gadgets Now"
+          class="logoGadgets"
+          src="logo-gadgets-now.png"
+        />
+      </div>
     </div>
   </section>
 </DocumentFragment>


### PR DESCRIPTION
- wrap h2 and news in `.body` div
- use background image properties instead of ::after
- fix img sizes
- fix div widths
- use [container query](https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_containment/Container_queries) to change flex justification when all logos can fit on one line
  - NOTE: This is _not_ a media query! I used the named-container scope to ensure it applies only to this one case. Container queries are meant to adjust content based on size of an element, and to be separate from media query breakpoints.