### PR TITLE
[NOTASK]: fix footer snapshot

### DIFF
--- a/src/components/Footer/__snapshots__/Footer.spec.js.snap
+++ b/src/components/Footer/__snapshots__/Footer.spec.js.snap
@@ -75,21 +75,21 @@ exports[`renders NotFound correctly and matches snapshot 1`] = `
       <div
         class="socialLinks"
       >
-        <img
-          alt="facebook"
+        <svg
           class="socialLink"
-          src="icon-facebook.svg"
-        />
-        <img
-          alt="Pinterest"
+        >
+          icon-facebook.svg
+        </svg>
+        <svg
           class="socialLink"
-          src="icon-pinterest.svg"
-        />
-        <img
-          alt="twitter"
+        >
+          icon-pinterest.svg
+        </svg>
+        <svg
           class="socialLink"
-          src="icon-twitter.svg"
-        />
+        >
+          icon-twitter.svg
+        </svg>
       </div>
       <p
         class="copyright avoidWrap body2"


### PR DESCRIPTION
Footer snapshot was updated in #46 for a switch to plain img tag that was rejected, but spec was merged anyway by accident